### PR TITLE
Fix NullPointerException in trinkets()

### DIFF
--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityStateRenderMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityStateRenderMixin.java
@@ -26,6 +26,6 @@ public class LivingEntityStateRenderMixin implements TrinketEntityRenderState {
 
     @Override
     public List<Pair<ItemStack, SlotReference>> trinkets$getState() {
-        return this.trinketsState;
-    }
+        return this.trinketsState == null ? List.of() : this.trinketsState;
+}
 }


### PR DESCRIPTION
Fixes NullPointerException when trinket state is accessed before initialization. Modified trinkets$getState() in LivingEntityStateRenderMixin to return empty list instead of null.